### PR TITLE
DTSSTCI-721

### DIFF
--- a/src/main/steps/upload-documents/template.njk
+++ b/src/main/steps/upload-documents/template.njk
@@ -64,7 +64,7 @@
 }) }}
 
          {% if uploadedDocuments.length > 0 %}
-    <dul class="govuk-list">
+    <ul class="govuk-list">
   {% for document in uploadedDocuments %}
       <li class="uploadedFile govuk-!-padding-top-2 govuk-!-padding-bottom-3 govuk-section-break govuk-section-break--visible">
         {{ document.fileName }}


### PR DESCRIPTION
### Change description

Changed a typo'd HTML tag from "dul" to "ul" in template.njk in the upload-documents directory. The repository has also been searched for other repeated mistakes and from what I can see, there are no other \<li> elements that have not been encapsulated by a parent \<ul> tag.

### JIRA link

https://tools.hmcts.net/jira/browse/DTSSTCI-721