### PR TITLE
DTSSTCI-720

### DIFF
--- a/src/main/steps/dss-update/check-your-answers/form.njk
+++ b/src/main/steps/dss-update/check-your-answers/form.njk
@@ -14,7 +14,7 @@
     
       {% endif %}
     {% endfor %}
-      <h2 class="govuk-heading-l">{{submitApplicationText}}</h2>
+      <h2 class="govuk-heading-m">{{submitApplicationText}}</h2>
       <p class="govuk-body-l">{{statementOfTruth}}</p>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Change description

The h1 tag in form.njk in the "check-your-answers" directory has been changed to an h2 tag as advised by the screen readers comments in the ticket: "Changing the second h1 to an h2 would provide a hierarchical structure and a more familiar navigational experience which will resolve any potential difficulties the current layout may cause."

~~The class of the h1 tag, however, has been kept the same, should the PO require that the design of the text itself be kept the same rather than made smaller (for example).~~ The class of the tag has been updated inline with other large heading 2 elements: https://design-system.service.gov.uk/styles/headings/

### JIRA link

https://tools.hmcts.net/jira/browse/DTSSTCI-720