### PR TITLE
DTSSTCI-722

### DIFF
--- a/src/main/steps/upload-documents/template.njk
+++ b/src/main/steps/upload-documents/template.njk
@@ -18,7 +18,7 @@
 
 {%endif%}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-7">{{title}}</h1>
+<label for="documentDetail"><h1 class="govuk-heading-l govuk-!-margin-top-7">{{title}}</h1></label>
  <form action="{{postURL}}/upload-documents" method="post" enctype="multipart/form-data">
 <div class="{% if textAreaErrorMsg %}govuk-form-group--error {%endif%}">
   {%if textAreaErrorMsg %}


### PR DESCRIPTION
### Change description

In template.njk in the upload-documents directory, label tags have been added for the page's heading 1 element. This is to associate it with the first textbox on the upload-documents page, so that screenreaders are given a description with which to communicate the purpose of the textbox to the user.

### JIRA link

https://tools.hmcts.net/jira/browse/DTSSTCI-722